### PR TITLE
Exclude `test` task in production environment

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:test)
+unless Rails.env.production?
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:test)
+end


### PR DESCRIPTION
Gems needed for testing not bundled in `:production` group